### PR TITLE
Update hourly_qff_to_cdm_core_v2.py

### DIFF
--- a/PYTHON_CDM_Conversion_code/hourly_qff_to_cdm_core_v2.py
+++ b/PYTHON_CDM_Conversion_code/hourly_qff_to_cdm_core_v2.py
@@ -271,12 +271,12 @@ def main(station="", subset="", run_all=False, clobber=False):
         df["station_type"] = "1"
         df["observation_id"] = ""
         df["data_policy_licence"] = ""
-        df["primary_station_id"] = df["Station_ID"]
+        df["primary_station_id"] = df["STATION"]
         df["secondary_id"] = ""                                   
         df["station_name"] = df["Station_name"]
         df["quality_flag"] = ""
-        df["latitude"] = pd.to_numeric(df["Latitude"], errors='coerce')
-        df["longitude"] = pd.to_numeric(df["Longitude"], errors='coerce')
+        df["latitude"] = pd.to_numeric(df["LATITUDE"], errors='coerce')
+        df["longitude"] = pd.to_numeric(df["LONGITUDE"], errors='coerce')
         df["latitude"] = df["latitude"].round(3)
         df["longitude"]=  df["longitude"].round(3)
         df["Timestamp2"] = df["Year"].map(str) + "-" +\


### PR DESCRIPTION
Hi Robert,
Below are the required edits for the new column header format (capitals). Can you please check over.

Edits for r8 based on some new column headers in capitals

hourly_qff_to_cdm_core_v2.py 

we overwrite the location using a function but the code initial reads in the Latitude Longitude and Station_ID and these are now capitals.

line 262  df["height_of_station_above_sea_level"]="" should be ok but check pls 
line 264  df["latitude"] = "" should be ok but -check pls 
line 265  df["longitude"] ="" should be ok but-check pls

line 278  df["latitude"] = pd.to_numeric(df["Latitude"], errors='coerce')now capitals in /MFF/QFF LATITUDE  needed to be changed 

 line 279  df["longitude"] = pd.to_numeric(df["Longitude"], errors='coerce')now capitals in /MFF/QFF LONGITUDE  needed to be changed

line 274  df["primary_station_id"] = df["Station_ID"] now capitals in /MFF/QFF as "STATION" needed to be changed


Can you also please check the following  CDM utils code , I am 90% sure no edits are required but need a second pair of yes to check please.

hourly_qff_to_cdm_utils.py

line 204   var_frame = location_frame.merge(var_frame, on=['primary_station_id']) we overwrite the location using a function and the code reads in the Station_ID from STATION now. This should be OK as hourly_qff_to_cdm_core_v2.py reads "STATION"  in now see above changes:

line 207   var_frame['latitude'] = var_frame['latitude_x'] now capitals in /MFF/QFF LATITUDE but not sure if needs to be changed -check pls

line 208   var_frame['longitude'] = var_frame['longitude_x']now capitals in /MFF/QFF LONGITUDE but not sure if needs to be changed -check pls

line 209   var_frame['height_of_station_above_sea_level'] = var_frame['height_of_station_above_sea_level_x'] this should be ok as we do not call elevation from QFF in hourly_qff_to_cdm_core_v2.py.

cheers
Simon
